### PR TITLE
Add env for the TTGO Lora32 v2.1.6 board

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -281,3 +281,23 @@ upload_port = 192.168.2.38
 ;board_build.flash_mode = qio
 ;upload_speed = 115200
 ;upload_port = 192.168.2.174
+
+;[env:Gateway_ttgo-lora32-v21]
+;platform = espressif32
+;board = ttgo-lora32-v21
+;framework = arduino
+;upload_speed = 115200
+;monitor_speed = 115200
+;build_flags =
+;  -D _WIFIMANAGER=0
+;  -D _OLED=1
+;  -D _DUSB=1
+;  -D _PROFILER=1
+;  -D _SPIFFS_FORMAT=1
+;  -D _STAT_LOG=0
+;  -D _PIN_OUT=5
+;;  -D _JSONENCODE=1
+;;  -D _MAXSEEN=20
+;;upload_protocol = espota
+;;board_build.flash_mode = qio
+;;upload_port = 192.168.2.152


### PR DESCRIPTION
This settings seems to works  for the board TTGO Lora32 v2.1.6 board.

Tested on TTN v3, gateway shown connected.

OLED works.